### PR TITLE
Handle list of QuantumCircuit objects in job memory mapping

### DIFF
--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -17,8 +17,6 @@
 import time
 
 import requests
-from qiskit import QuantumCircuit
-
 from qiskit.providers import JobV1
 from qiskit.providers import JobError
 from qiskit.providers import JobTimeoutError

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -79,7 +79,10 @@ class AQTJob(JobV1):
         qubit_map = {}
         count = 0
 
-        if isinstance(self.qobj[0], QuantumCircuit):
+        # If a list of quantum circuits use the first element
+        # since we only can have a maximum of a single
+        # circuit per job.
+        if isinstance(self.qobj, list):
             self.qobj = self.qobj[0]
 
         for bit in self.qobj.qubits:

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -17,6 +17,7 @@
 import time
 
 import requests
+from qiskit import QuantumCircuit
 
 from qiskit.providers import JobV1
 from qiskit.providers import JobError
@@ -77,6 +78,10 @@ class AQTJob(JobV1):
             return qu2cl
         qubit_map = {}
         count = 0
+
+        if isinstance(self.qobj[0], QuantumCircuit):
+            self.qobj = self.qobj[0]
+
         for bit in self.qobj.qubits:
             qubit_map[bit] = count
             count += 1

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -14,7 +14,6 @@
 # pylint: disable=protected-access
 
 import unittest
-
 import numpy as np
 
 from qiskit import QuantumCircuit, transpile
@@ -42,6 +41,20 @@ class TestJobs(unittest.TestCase):
         qc.measure(range(5), perm)
 
         job = _FakeJob(qc)
+        mapping = job._build_memory_mapping()
+
+        self.assertEqual(mapping[0], perm[0])
+        self.assertEqual(mapping[2], perm[2])
+
+    def test_job_counts_measurement_mapping_with_circuit_list(self):
+        """Are measurements correctly mapped to counts with circuit list"""
+        perm = np.random.permutation(5)
+        qc = QuantumCircuit(5, 5)
+        qc.x(0)
+        qc.x(2)
+        qc.measure(range(5), perm)
+
+        job = _FakeJob([qc])
         mapping = job._build_memory_mapping()
 
         self.assertEqual(mapping[0], perm[0])

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -14,6 +14,7 @@
 # pylint: disable=protected-access
 
 import unittest
+from unittest import mock
 
 import numpy as np
 

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -14,7 +14,6 @@
 # pylint: disable=protected-access
 
 import unittest
-from unittest import mock
 
 import numpy as np
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #46 

### Details and comments

set `self.qobj` to given QuantumCircuit

