### PR TITLE
Preserve circuit metadata in output result

### DIFF
--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -151,7 +151,8 @@ class AQTJob(JobV1):
                     'shots': len(result['samples']),
                     'data': {'counts': self._format_counts(result['samples'])},
                     'header': {'memory_slots': self.qobj.num_clbits,
-                               'name': self.qobj.name}
+                               'name': self.qobj.name,
+                               'metadata': self.qobj.metadata}
                 }]
             qobj_id = id(self.qobj)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the Result objects generated by the
AqtJob. Previously the metadata from the input circuit was not passed to
the result header. This causes applications (like Qiskit Experiments) to
not be able to use the circuit metadata for tracking purposes. This
commit fixes this oversight by adding any circuit metadata to the output
result header.

### Details and comments