### PR TITLE
Fix docs build for Sphinx 5.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ numfig = True
 numfig_format = {
     'table': 'Table %s'
 }
-language = None
+language = "en"
 
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Sphinx 5.0 was recently released and as part of that not specifying a
default launguage now emits a warning (which is fatal with -W set). This
commit fixes the configuration to explicitly say the default language is
English.

### Details and comments