### PR TITLE
Stop installing terra from source

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
 deps = 
-  git+https://github.com/Qiskit/qiskit-terra.git
   -r{toxinidir}/requirements-dev.txt
   requests>=2.19
   setuptools>=40.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There isn't a need to install terra from source in testing anymore (although I don't remember why it was done originally). This commit removes this from the tox configuration.

### Details and comments


